### PR TITLE
fix(deploy): trigger Pages from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy VitePress site to Pages
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 变更

- 将 VitePress Pages workflow 的 push 触发分支从 `dev` 改为 `main`
- 保留 `workflow_dispatch` 手动触发入口

## 原因

`main` 是受保护的发布分支；发布 PR `dev → main` 合并后应触发 Pages 构建与部署。

## 验证

- `git diff --check`
- Ruby YAML 解析通过
- 仅修改 `.github/workflows/deploy.yml` 一行