### PR TITLE
fix(deploy): trigger Pages from main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy VitePress site to Pages
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## 变更

- 将 `.github/workflows/deploy.yml` 的 push 触发分支从 `dev` 改为 `main`
- 保留 `workflow_dispatch` 手动触发入口

## 发布行为

此 PR 合并到 `main` 后，合并产生的 push 会触发 VitePress Pages 构建与部署。

## 验证

- YAML 解析通过
- `git diff --check` 通过
- `dev → main` 的实际文件差异仅为 workflow 的 1 行修改
- 修复已通过 #23 合入受保护的 `dev`

## 发布检查

- [x] 来源分支为 `dev`
- [x] 目标分支为 `main`
- [ ] 完成至少 1 个 approving review