### PR TITLE
fix(ui): 修复导航标题截断与章节组件重复

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -20,6 +20,7 @@ function prepareMathSvgTemplate(value: string) {
 
 const isEdgeOne = process.env.EDGEONE === '1'
 const baseConfig = isEdgeOne ? '/' : '/hello-gpu/'
+const configuredMarkdownRenderers = new WeakSet<object>()
 
 export default defineConfig({
   lang: 'zh-CN',
@@ -54,6 +55,11 @@ export default defineConfig({
   markdown: {
     math: true,
     config(md) {
+      // Client/server builds can initialize the same renderer concurrently.
+      // Register plugins and renderer wrappers only once on each instance.
+      if (configuredMarkdownRenderers.has(md)) return
+      configuredMarkdownRenderers.add(md)
+
       md.use(footnote)
       md.use(figurePlugin)
       md.use(editorialPlugin)

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -145,11 +145,26 @@ a, button {
   max-width: 1680px !important;
 }
 
-.VPNavBar.has-sidebar .title {
+.VPNavBar > .wrapper > .container > .title {
+  flex-shrink: 0;
+  min-width: 0;
+  max-width: none;
+}
+
+.VPNavBar.has-sidebar > .wrapper > .container > .title {
   position: relative !important;
   width: auto !important;
   left: auto !important;
   padding: 0 !important;
+}
+
+/* The brand and tagline share a link, so neither should inherit the sidebar's width cap. */
+.VPNavBar .VPNavBarTitle.has-sidebar {
+  max-width: none;
+}
+
+.VPNavBarTitle .title > span {
+  flex-shrink: 0;
 }
 
 .VPNavBar.has-sidebar .content {

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "scripts": {
     "docs:sync-outline": "node docs/.vitepress/sync-outline.mjs",
     "docs:check-outline": "node docs/.vitepress/sync-outline.mjs --check",
+    "docs:check-chapter-ui": "node scripts/check-chapter-ui.mjs",
     "docs:build-images": "node scripts/png-to-webp.mjs",
     "docs:build-atlas": "node scripts/build-atlas.mjs",
     "docs:dev": "npm run docs:sync-outline && npm run docs:build-images && npm run docs:build-atlas && vitepress dev docs",
-    "docs:build": "npm run docs:sync-outline && npm run docs:build-images && npm run docs:build-atlas && vitepress build docs",
+    "docs:build": "npm run docs:sync-outline && npm run docs:build-images && npm run docs:build-atlas && vitepress build docs && npm run docs:check-chapter-ui",
     "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
@@ -14,7 +15,7 @@
     "markdown-it-footnote": "^4.0.0",
     "markdown-it-mathjax3": "^4.3.2",
     "mermaid": "^11.14.0",
-    "vitepress": "^2.0.0-alpha.16",
+    "vitepress": "2.0.0-alpha.18",
     "vue": "^3.5.0"
   },
   "devDependencies": {

--- a/scripts/check-chapter-ui.mjs
+++ b/scripts/check-chapter-ui.mjs
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { chapters } from '../docs/.vitepress/outline.mjs'
+
+if (process.argv.length > 3) {
+  console.error('Usage: node scripts/check-chapter-ui.mjs [output-directory]')
+  process.exit(1)
+}
+
+const repoRoot = fileURLToPath(new URL('../', import.meta.url))
+const outputDir = process.argv[2]
+  ? resolve(process.argv[2])
+  : resolve(repoRoot, 'docs/.vitepress/dist')
+const failures = []
+
+// Count rendered elements, excluding inline code and styles that can mention UI classes.
+function renderedClasses(html) {
+  const markup = html
+    .replace(/<!--[^]*?-->/g, '')
+    .replace(/<(script|style)\b[^>]*>[^]*?<\/\1\s*>/gi, '')
+  const classes = []
+
+  for (const [tag] of markup.matchAll(/<[a-z][\w:-]*\b(?:[^"'<>]|"[^"]*"|'[^']*')*>/gi)) {
+    for (const attribute of tag.matchAll(/\s+([^\s"'<>/=]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+)))?/g)) {
+      if (attribute[1].toLowerCase() === 'class') {
+        classes.push((attribute[2] ?? attribute[3] ?? attribute[4] ?? '').split(/\s+/))
+      }
+    }
+  }
+
+  return classes
+}
+
+for (const chapter of chapters) {
+  const htmlPath = resolve(outputDir, chapter.source.replace(/^docs\//, '').replace(/\.md$/, '.html'))
+  let html
+
+  try {
+    html = readFileSync(htmlPath, 'utf8')
+  } catch (error) {
+    failures.push(`${chapter.source}: cannot read ${htmlPath} (${error.code ?? error.message})`)
+    continue
+  }
+
+  const classes = renderedClasses(html)
+  const count = (className) => classes.filter((tokens) => tokens.includes(className)).length
+  const expectedCounts = {
+    'hg-chapter-meta': 1,
+    'hg-chapter-prelude': 1,
+    // Chapter 19 describes a separate hardware baseline in its own content.
+    'hg-chapter-baseline': chapter.number === 19 ? 0 : 1,
+    'hg-reading-route-cards': chapter.part.prefix === '/part2-kernels/' ? 1 : 0,
+  }
+
+  for (const [className, expected] of Object.entries(expectedCounts)) {
+    const actual = count(className)
+    if (actual !== expected) {
+      failures.push(`${chapter.source}: .${className} expected ${expected}, found ${actual}`)
+    }
+  }
+
+  const guides = count('hg-reading-guide')
+  if (guides > 1) {
+    failures.push(`${chapter.source}: .hg-reading-guide expected at most 1, found ${guides}`)
+  }
+
+  const repeatedLeads = classes.filter((tokens) => tokens.filter((token) => token === 'hg-chapter-lead').length > 1).length
+  if (repeatedLeads > 0) {
+    failures.push(`${chapter.source}: repeated hg-chapter-lead class on ${repeatedLeads} element(s)`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`Chapter UI check failed: ${chapters.length} chapters checked, ${failures.length} violation(s).`)
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exitCode = 1
+} else {
+  console.log(`Chapter UI check passed: ${chapters.length} chapters checked; chapter metadata and reading guides are not duplicated.`)
+}


### PR DESCRIPTION
修复章节页的两处显示问题：左上角品牌被截断为 “Hello …”，以及章首“配套代码”“实验基线”和 HIP/Triton 阅读路线重复出现。合并后，品牌完整显示，公共章节组件只生成一份。

- 调整导航品牌区域的宽度约束，使标题和副标语按实际内容占宽；保留移动端隐藏副标语的行为。
- 对 Markdown 渲染器配置增加一次性初始化保护，避免并行构建时重复注册插件、重复插入章节组件。
- 将 VitePress 固定为已验证的 `2.0.0-alpha.18`，使本地与部署使用一致版本。
- 在 `docs:build` 末尾增加全量章节 UI 检查，覆盖全部 20 章；发现重复元信息、实验基线、路线卡片或阅读导引时构建失败。

验证：

- 复现线上导航截断，并验证修复后在 320–2560px 宽度下完整显示、无导航重叠。
- 使用 VitePress `alpha.20` 的生产构建复现章节重复；新增检查能拦下该错误产物。
- 使用全新安装的依赖完成完整站点及 NVIDIA Atlas 构建，全部 20 章 UI 检查通过。
- 浏览器检查全部 20 章，复核第 5、8 章的深浅主题、移动端、章节跳转及返回，无重复组件或运行时 / hydration 错误。
- `npm run docs:check-outline` 和 Git 差异检查通过。构建仍有现有的部分产物超过 500 kB 提示。
